### PR TITLE
Remove dependency on lucene-querybuilder and make compatible with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,6 @@ If you'd rather search for authors, try ORCID's search functionality ::
     >>> print next(authors).family_name
     wilbanks
 
-You can also accomplish more complex queries using `Q` objects and fields ::
-
-    >>> from orcid import Q
-    >>> authors = orcid.search(Q('given-name','john') & Q('family-name', 'wilbanks'))
-    >>> print next(authors).family_name
-    wilbanks
-
 ### Credits
 
 Cloned from the repository https://github.com/scholrly/orcid-python lead by [Matt Luongo](https://github.com/mhluongo) from [Scholrly](https://github.com/scholrly/)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Manual installation (or usage):
 ### Dependencies
 
 * requests>=1.0.4
-* lucene-querybuilder>=0.1.6
 
 Install dependencies with pip
 ```

--- a/examples/extracting_bibtex.py
+++ b/examples/extracting_bibtex.py
@@ -28,19 +28,19 @@ def show_keyword(obj):
         Printing author keywords
     """
 
-    print '[i] printing author keywords'
+    print('[i] printing author keywords')
     keywords = obj.keywords
     for key_word in keywords:
-        print key_word
+        print(key_word)
 
 def print_publications(obj):
     """
         Printing author publications
     """
 
-    print '[i] printing author publications'
+    print('[i] printing author publications')
     for value in obj.publications:
-        print value
+        print(value)
 
 def save_bibtex(bibtex, file_name='orcid-bibtex-output.bib', encoding='utf-8'):
     """
@@ -62,7 +62,7 @@ def save_bibtex(bibtex, file_name='orcid-bibtex-output.bib', encoding='utf-8'):
 
     _file.close()
 
-    print '[i] bibtex was created, check following file: %s ' % (file_name)
+    print('[i] bibtex was created, check following file: %s ' % (file_name))
 
 def save_nocite(bibtex, file_name='orcid-nocite-output.tex', encoding='utf-8'):
     """
@@ -89,7 +89,7 @@ def save_nocite(bibtex, file_name='orcid-nocite-output.tex', encoding='utf-8'):
 
     _file.close()
 
-    print '[i] tex with \\nocite was created, check following file: %s ' % (file_name)
+    print('[i] tex with \\nocite was created, check following file: %s ' % (file_name))
 
 def extract_bitex(obj):
     """
@@ -107,7 +107,7 @@ def extract_bitex(obj):
             else:
                 bibtex[value.publicationyear].append(value.citation.citation)
         else:
-            print '[i] this publications is having no BIBTEX %s ' % (value)
+            print('[i] this publications is having no BIBTEX %s ' % (value))
 
     return bibtex
 

--- a/examples/orcid_bibtex_to_html.py
+++ b/examples/orcid_bibtex_to_html.py
@@ -34,7 +34,7 @@ UMLAUT_TO_LATEX = {
 
 
 def log_traceback(ex, ex_traceback=None):
-    print '[i] exception happened, check log file'
+    print('[i] exception happened, check log file')
 
     if ex_traceback is None:
         ex_traceback = ex.__traceback__
@@ -141,7 +141,7 @@ def save_bibtex(bibtex, file_prefix='orcid-bibtex-output', separate=False, encod
         _file.close()
 
 
-    print '[i] file with bibtex was created, check it here: %s ' % (file_name)
+    print('[i] file with bibtex was created, check it here: %s ' % (file_name))
 
 def form_bibtex(authors, title, year):
     """
@@ -163,7 +163,7 @@ def form_bibtex(authors, title, year):
 
 def dump(obj):
   for attr in dir(obj):
-    print "obj.%s = %s" % (attr, getattr(obj, attr))
+    print("obj.%s = %s" % (attr, getattr(obj, attr)))
 
 def extract_bitex(obj, author):
     """
@@ -189,10 +189,10 @@ def extract_bitex(obj, author):
                         bibtex[value.publicationyear].append(value.citation.citation)
                 else:
                     nobibtex.append(form_bibtex([author], value.title, value.publicationyear))
-                    print '[i] this publications is having no BIBTEX, new BIBTEX was generated {0}'.format(value.title)
+                    print('[i] this publications is having no BIBTEX, new BIBTEX was generated {0}'.format(value.title))
             else:
                 nobibtex.append(form_bibtex([author], value.title, value.publicationyear))
-                print '[i] this publications is having no BIBTEX, new BIBTEX was generated {0}'.format(value.title)
+                print('[i] this publications is having no BIBTEX, new BIBTEX was generated {0}'.format(value.title))
         except Exception as ex:
             _, _, ex_traceback = sys.exc_info()
             log_traceback(ex, ex_traceback)
@@ -228,7 +228,7 @@ def main():
         name = key
         years[name] = list()
         orcidid = orcid_list[key]
-        print '[i] extracting bibtex for {0}'.format(name)
+        print('[i] extracting bibtex for {0}'.format(name))
         orcid_obj = orcid.get(orcidid)
 
         # extracting bibtex
@@ -249,7 +249,7 @@ def main():
             log_traceback(ex, ex_traceback)
 
 
-    print  years
+    print(years)
     generate_bat(orcid_extracted, separate=separate_by_year, years = years)
 
 if __name__ == '__main__':

--- a/pyorcid/__init__.py
+++ b/pyorcid/__init__.py
@@ -1,4 +1,3 @@
-__all__ = ('get', 'search', 'Q')
+__all__ = ('get', 'search')
 
 from .rest import get, search
-from lucenequerybuilder import Q

--- a/pyorcid/rest.py
+++ b/pyorcid/rest.py
@@ -4,7 +4,7 @@ import requests
 import json
 
 from .constants import ORCID_PUBLIC_BASE_URL
-from .utils import dictmapper, MappingRule as to
+from .utils import dictmapper, u, MappingRule as to
 
 from .exceptions import NotFoundException
 
@@ -64,7 +64,7 @@ ExternalIDBase = dictmapper('ExternalIDBase', {
 
 class ExternalID(ExternalIDBase):
     def __unicode__(self):
-        return unicode(self.id)
+        return u(self.id)
 
     def __repr__(self):
         return '<%s %s:%s>' % (type(self).__name__, self.type, str(self.id))
@@ -139,7 +139,7 @@ def get(orcid_id):
     """
     Get an author based on an ORCID identifier.
     """
-    resp = requests.get(ORCID_PUBLIC_BASE_URL + unicode(orcid_id),
+    resp = requests.get(ORCID_PUBLIC_BASE_URL + u(orcid_id),
                         headers=BASE_HEADERS)
     write_logs(resp)
     json_body = resp.json()
@@ -149,7 +149,7 @@ def get(orcid_id):
 #     """
 #     Get an author based on an ORCID identifier and json
 #     """
-#     resp = requests.get(ORCID_PUBLIC_BASE_URL + unicode(orcid_id),
+#     resp = requests.get(ORCID_PUBLIC_BASE_URL + u(orcid_id),
 #                         headers=BASE_HEADERS)
 #     json_body = resp.json()
 #     write_logs(resp)
@@ -157,7 +157,7 @@ def get(orcid_id):
 
 def search(query):
     resp = requests.get(ORCID_PUBLIC_BASE_URL + 'search/orcid-bio',
-                        params={'q':unicode(query)}, headers=BASE_HEADERS)
+                        params={'q':u(query)}, headers=BASE_HEADERS)
     json_body = resp.json()
     return (Author(res) for res in json_body.get('orcid-search-results', {})\
             .get('orcid-search-result'))

--- a/pyorcid/utils.py
+++ b/pyorcid/utils.py
@@ -1,3 +1,5 @@
+import sys
+
 def dict_value_from_path(d, path):
     cur_dict = d
     for key in path[:-1]:
@@ -35,7 +37,7 @@ def dictmapper(typename, mapping):
         return getter
 
     prop_mapping = dict((k, property(getter_from_dict_path(v))) 
-                        for k, v in mapping.iteritems())
+                        for k, v in mapping.items())
     prop_mapping['__init__'] = init
     return type(typename, tuple(), prop_mapping)
 
@@ -46,3 +48,9 @@ class MappingRule(object):
 
     def __call__(self, d):
         return self.further_func(dict_value_from_path(d, self.path))
+
+def u(s):
+    if sys.version_info < (3,):
+        return unicode(s)
+    else:
+        return str(s)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=1.0.4
-lucene-querybuilder>=0.1.6

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,5 @@ setup(name='pyorcid',
       packages=['pyorcid'],
       install_requires=[
                       'requests>=1.0.4',
-                      'lucene-querybuilder>=0.1.6',
                   ]
      )


### PR DESCRIPTION
The lucene-querybuilder dependency was not really a dependency at all. The only reason it existed was to re-export a function from that module. If someone wants to use the query builder, they can download the library themselves, and import the function directly from the lucenequerybuilder module.

Additionally, the commits included here improve compatibility with python3.
